### PR TITLE
Make indexutil-annotate fail when no units are found

### DIFF
--- a/Sources/indexutil-annotate/main.swift
+++ b/Sources/indexutil-annotate/main.swift
@@ -5,11 +5,18 @@ func main(_ storePath: String, _ sourcePath: String) throws {
     let store = try IndexStore(path: storePath)
 
     var recordName: String?
+    var foundUnits = false
     for unitReader in store.units {
+        foundUnits = true
         if unitReader.mainFile == sourcePath {
             recordName = unitReader.recordName
             break
         }
+    }
+
+    if !foundUnits {
+        fputs("error: no records found, your index store might be invalid?\n", stderr)
+        exit(EXIT_FAILURE)
     }
 
     if recordName == nil {


### PR DESCRIPTION
This normally happens when passing the wrong path to the index store
