### PR TITLE
Add support for demangling other USR types

### DIFF
--- a/Sources/CSwiftDemangle/CSwiftDemangle.cpp
+++ b/Sources/CSwiftDemangle/CSwiftDemangle.cpp
@@ -27,7 +27,9 @@ demangle_node_t demangle_symbolAsNode(demangle_context_t ctx, const char *symbol
   // USRs in the index have a prefix of s: instead of $S. Copy the string and change the first two letters.
   if (strncmp("s:", symbol, 2) == 0) {
     char true_symbol[strlen(symbol) + 1];
-    strcpy(true_symbol, symbol);
+    // Get the index before the last colon because we replace the first 2 characters below.
+    const char *str_before_colon = strrchr(symbol, ':') - 1;
+    strcpy(true_symbol, str_before_colon);
     strncpy(true_symbol, "$S", 2);
     return ctx->demangleSymbolAsNode(true_symbol);
   }

--- a/Tests/SwiftDemangleTests/SwiftDemangleTests.swift
+++ b/Tests/SwiftDemangleTests/SwiftDemangleTests.swift
@@ -1,12 +1,14 @@
 import XCTest
 import SwiftDemangle
 
+private let kCommonSymbol = "s:10DriverCore28AddPhoneVerifyViewControllerC28resendCodeViaVoiceCallButton33_3079D27A166598D3B3B79EAC945873F9LLSo8UIButtonCSgvp"
+private let kExtensionUSR = "s:e:s:14Unidirectional14EffectProducerV10Onboarding7LyftKit13NonemptyStackVyAD0D5StateV_yAD9GuestUserOctGRszAD0D10ActionMask_pRs_rlE010submitNameB0ACyAldM_pGvpZ"
+
 final class SwiftDemangleTests: XCTestCase {
-    private static let CommonSymbol = "s:10DriverCore28AddPhoneVerifyViewControllerC28resendCodeViaVoiceCallButton33_3079D27A166598D3B3B79EAC945873F9LLSo8UIButtonCSgvp"
 
     func testDemangle() throws {
         let demangler = Demangler()
-        let root = try XCTUnwrap(demangler.demangle(symbol: Self.CommonSymbol))
+        let root = try XCTUnwrap(demangler.demangle(symbol: kCommonSymbol))
         let moduleNode = root.children[0].children[0].children[0]
         try XCTAssertEqual(XCTUnwrap(moduleNode.text), "DriverCore")
         let classNode = root.children[0].children[0].children[1]
@@ -19,9 +21,16 @@ final class SwiftDemangleTests: XCTestCase {
         XCTAssertNil(demangler.demangle(symbol: symbol))
     }
 
+    func testSwiftExtensionUSR() throws {
+        let demangler = Demangler()
+        let root = try XCTUnwrap(demangler.demangle(symbol: kExtensionUSR))
+        let modules = Set(root.breadthFirstSequence().filter { $0.kind == .module }.compactMap { $0.text })
+        XCTAssertEqual(modules, ["Unidirectional", "Onboarding", "LyftKit"])
+    }
+
     func testBreathFirstSequence() throws {
         let demangler = Demangler()
-        let root = try XCTUnwrap(demangler.demangle(symbol: Self.CommonSymbol))
+        let root = try XCTUnwrap(demangler.demangle(symbol: kCommonSymbol))
         let textNodes = root.breadthFirstSequence().compactMap { $0.text }
         XCTAssertEqual(textNodes, [
             "DriverCore",


### PR DESCRIPTION
Usrs sometimes have multiple leading identifiers, in this case `e:` for
extension. Previously we supported stripping a single `s:`, now we
support stripping all the leading identifiers as long as they still
start with `s:` (and not `c:` like some Objective-C USRs).
