### PR TITLE
Fix libswiftDemangle path

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -31,6 +31,13 @@ swift_library(
 swift_library(
     name = "SwiftDemangle",
     srcs = glob(["Sources/SwiftDemangle/*.swift"]),
+    linkopts = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": [
+            "-Wl,-force_load,__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/libswiftDemangle.dylib",
+            "-Wl,-rpath,__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+        ],
+    }),
     module_name = "SwiftDemangle",
     visibility = [
         "//visibility:public",

--- a/Package.swift
+++ b/Package.swift
@@ -17,10 +17,12 @@ let linkerSettings: [LinkerSetting]? = {
     return [
         .unsafeFlags(["-L\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib"]),
         .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib"]),
+        // This is a hack to get Xcode's version instead of the system installed version
+        .unsafeFlags(["-Xlinker", "-force_load", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libswiftDemangle.dylib"]),
     ]
 }()
 #else
-let linkerSettings: [LinkerSetting]? = nil
+let linkerSettings: [LinkerSetting] = [.linkedLibrary("swiftDemangle")]
 #endif
 
 let package = Package(
@@ -43,8 +45,7 @@ let package = Package(
         .testTarget(name: "IndexStoreTests", dependencies: ["IndexStore"], exclude: ["BUILD", "Data"]),
         .target(
             name: "CSwiftDemangle",
-            cxxSettings: [.headerSearchPath("PrivateHeaders/include")],
-            linkerSettings: [.linkedLibrary("swiftDemangle")]
+            cxxSettings: [.headerSearchPath("PrivateHeaders/include")]
         ),
         .target(name: "SwiftDemangle", dependencies: ["CSwiftDemangle"]),
         .testTarget(name: "SwiftDemangleTests", dependencies: ["SwiftDemangle"], exclude: ["BUILD"]),

--- a/Package.swift
+++ b/Package.swift
@@ -4,25 +4,32 @@ import PackageDescription
 
 #if os(macOS)
 import Foundation
-let linkerSettings: [LinkerSetting]? = {
-    let process = Process()
-    process.launchPath = "/usr/bin/xcode-select"
-    process.arguments = ["-p"]
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.launch()
-    process.waitUntilExit()
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let XcodePath = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .newlines)
-    return [
-        .unsafeFlags(["-L\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib"]),
-        .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib"]),
-        // This is a hack to get Xcode's version instead of the system installed version
-        .unsafeFlags(["-Xlinker", "-force_load", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libswiftDemangle.dylib"]),
-    ]
-}()
+
+let process = Process()
+process.launchPath = "/usr/bin/xcode-select"
+process.arguments = ["-p"]
+let pipe = Pipe()
+process.standardOutput = pipe
+process.launch()
+process.waitUntilExit()
+let data = pipe.fileHandleForReading.readDataToEndOfFile()
+let XcodePath = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .newlines)
+
+let indexLinkerSettings: [LinkerSetting] = [
+    .unsafeFlags(["-L\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib"]),
+    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib"]),
+]
+
+let swiftDemangleLinkerSettings: [LinkerSetting] = [
+    .unsafeFlags(["-L\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"]),
+    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"]),
+    // This is a hack to get Xcode's version instead of the system installed version
+    .unsafeFlags(["-Xlinker", "-force_load", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libswiftDemangle.dylib"]),
+]
+
 #else
-let linkerSettings: [LinkerSetting] = [.linkedLibrary("swiftDemangle")]
+let indexLinkerSettings: [LinkerSetting] = []
+let swiftDemangleLinkerSettings: [LinkerSetting] = [.linkedLibrary("swiftDemangle")]
 #endif
 
 let package = Package(
@@ -41,11 +48,12 @@ let package = Package(
     ],
     targets: [
         .target(name: "CIndexStore"),
-        .target(name: "IndexStore", dependencies: ["CIndexStore"], linkerSettings: linkerSettings),
+        .target(name: "IndexStore", dependencies: ["CIndexStore"], linkerSettings: indexLinkerSettings),
         .testTarget(name: "IndexStoreTests", dependencies: ["IndexStore"], exclude: ["BUILD", "Data"]),
         .target(
             name: "CSwiftDemangle",
-            cxxSettings: [.headerSearchPath("PrivateHeaders/include")]
+            cxxSettings: [.headerSearchPath("PrivateHeaders/include")],
+            linkerSettings: swiftDemangleLinkerSettings
         ),
         .target(name: "SwiftDemangle", dependencies: ["CSwiftDemangle"]),
         .testTarget(name: "SwiftDemangleTests", dependencies: ["SwiftDemangle"], exclude: ["BUILD"]),

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,7 @@ let indexLinkerSettings: [LinkerSetting] = [
 ]
 
 let swiftDemangleLinkerSettings: [LinkerSetting] = [
-    .unsafeFlags(["-L\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"]),
-    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"]),
+    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib"]),
     // This is a hack to get Xcode's version instead of the system installed version
     .unsafeFlags(["-Xlinker", "-force_load", "-Xlinker", "\(XcodePath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libswiftDemangle.dylib"]),
 ]


### PR DESCRIPTION
This started picking up the system installed version which I believe is
new. This forces it to use Xcode's
