### PR TITLE
Enable sed command generated by unused-imports to correctly handle file paths containing spaces

### DIFF
--- a/Sources/unused-imports/main.swift
+++ b/Sources/unused-imports/main.swift
@@ -175,7 +175,7 @@ func main(
         if !unusedImports.isEmpty {
             let sedCmd = unusedImports.map { importsToLineNumbers[$0]! }.sorted().map { "\($0)d" }.joined(separator: ";")
             let relativePath = unitReader.mainFile.replacingOccurrences(of: pwd + "/", with: "")
-            print("/usr/bin/sed -i \"\" '\(sedCmd)' \(relativePath)")
+            print("/usr/bin/sed -i \"\" '\(sedCmd)' '\(relativePath)'")
         }
     }
 }


### PR DESCRIPTION
The `unused-imports` program currently generates `sed` invocations to remove import statements which operate on relative file paths, these paths should be quoted in order to handle the case where the path to the source file contains a space.