### PR TITLE
Fix generated file references

### DIFF
--- a/Sources/unnecessary-testable/main.swift
+++ b/Sources/unnecessary-testable/main.swift
@@ -176,17 +176,13 @@ func main(indexStorePath: String) {
             }
 
             seenModules.insert(moduleName)
-            if isGeneratedFile(dependentUnit.mainFile) {
-                continue
-            }
 
             recordReader.forEach { (occurrence: SymbolOccurrence) in
                 if
-                    occurrence.symbol.name.contains("I18N") ||
-                    (occurrence.roles.contains(.definition) &&
+                    occurrence.roles.contains(.definition) &&
                     referencedUSRs.contains(occurrence.symbol.usr) &&
                     !isChildOfProtocol(occurrence: occurrence) &&
-                    !isPublic(file: dependentUnit.mainFile, occurrence: occurrence))
+                    !isPublic(file: dependentUnit.mainFile, occurrence: occurrence)
                 {
                     requiredTestableImports.insert(moduleName)
                 }


### PR DESCRIPTION
Even though we don't evaluate generated files for testable imports, we
should take generated files into account for definitions in modules we
are importing with testable in other files. This fixes the I18N case
which was very Lyft specific as well.

This fixes the case where an internal type is defined in a generated
file, and therefore requires testable to be used. Previously if this was
the only definition being used we'd have a false positive.
