### PR TITLE
Fix incorrect regex

### DIFF
--- a/Sources/unnecessary-testable/main.swift
+++ b/Sources/unnecessary-testable/main.swift
@@ -6,7 +6,7 @@ private let kProtocolChildrenTypes: [SymbolKind] = [
     .instanceProperty, .classProperty, .staticProperty,
 ]
 private let testableRegex = try NSRegularExpression(
-    pattern: "^\\@testable import ([^ .]+)$", options: [.anchorsMatchLines])
+    pattern: "^\\@testable import ([^\\s.]+)$", options: [.anchorsMatchLines])
 
 private func getTestableImports(path: String) -> Set<String> {
     guard let searchText = try? String(contentsOfFile: path) else {


### PR DESCRIPTION
For the last testable import this included `\n` in the regex, leading
that module to be ignored later.
