### PR TITLE
Remove module name replacement

### DIFF
--- a/Sources/unnecessary-testable/main.swift
+++ b/Sources/unnecessary-testable/main.swift
@@ -190,7 +190,7 @@ func main(indexStorePath: String) {
                 continue
             }
 
-            let moduleName = dependentUnit.moduleName.replacingOccurrences(of: "Tests", with: "")
+            let moduleName = dependentUnit.moduleName
             guard testableImports.contains(moduleName) else {
                 continue
             }


### PR DESCRIPTION
I don't understand why we added this, the context was:

> the previous where testableImports.contains(dependentUnit.moduleName)
> would skip over the test files because test files would never show up
> in testableImports i.e. we don't ever see @testable import
> FooTests.

But I don't get that reasoning because you shouldn't ever be testable
importing your own module or any other Tests module, and if you have a
naming scheme where you do I don't think you want to skip them.
