### PR TITLE
Fix C API calls

### DIFF
--- a/Sources/IndexStore/IndexStore.swift
+++ b/Sources/IndexStore/IndexStore.swift
@@ -181,7 +181,7 @@ public final class UnitReader {
 
     public func forEach(dependency callback: (UnitDependency) -> Void) {
         withoutActuallyEscaping(callback) { callback in
-            let context = Context.init(callback: callback, this: self)
+            let context = Context(callback: callback, this: self)
             let pointer = context.pointer()
             indexstore_unit_reader_dependencies_apply_f(self.reader, pointer) { pointer, unitDependency in
                 if let unitDependency = unitDependency {


### PR DESCRIPTION
With Swift 5.9 our uses of the index C APIs warned with:

```
.../Sources/IndexStore/IndexStore.swift:299:66: warning: forming 'UnsafeMutableRawPointer' to a variable of type '(SymbolOccurrence, (Symbol, SymbolRoles) -> ())'; this is likely incorrect because '(SymbolOccurrence, (Symbol, SymbolRoles) -> ())' may contain an object reference.
```

And in our case things definitely contained object references. Assuming
this warning is valid I guess we were just lucky with our usage before.
Now we pass through a Context object that handles the state for us
instead.
